### PR TITLE
Make README grammar more clear, link to /new

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Issue Tracker for Hiven
 
-To report a bug or an issue see the issues page above or [here](https://github.com/hivenapp/issues/issues)
+To report a bug or an issue see the issues page above, or [click here](https://github.com/hivenapp/issues/issues/new).


### PR DESCRIPTION
Just some grammar stuff, and changing the issues link to /new, as its context is reporting bugs.